### PR TITLE
Fix NoiseOperation seed field

### DIFF
--- a/Textures/src/com/beder/texture/Operation.java
+++ b/Textures/src/com/beder/texture/Operation.java
@@ -17,8 +17,7 @@ import javax.swing.JSlider;
 import javax.swing.JTextField;
 
 public abstract class Operation implements Comparable<Operation> {
-	private Parameters param;
-	private Redrawable redraw;
+    private Redrawable redraw;
 	private JPanel controlPanel;
 	private Map<String, Component> controls;
 	protected enum CONTROL_TYPE {INT, DOUBLE, SLIDER, SEED};
@@ -51,17 +50,20 @@ public abstract class Operation implements Comparable<Operation> {
 	        controls.put(name, slider);
 	        controlPanel.add(slider);
 	        break;
-		case SEED:
-			JTextField seedField = new JTextField(String.format("%d", (long)def), 8); // FIX: store to seedField
-		    controls.put(name, seedField);
-		    controlPanel.add(seedField);
-		    JButton randomSeedButton = new JButton("Random");
-		    randomSeedButton.addActionListener(e -> {
-		        String newSeed = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-		        seedField.setText(newSeed);
-		    });
-		    controlPanel.add(randomSeedButton);
-		    break;
+                case SEED:
+                    JTextField seedField = new JTextField(String.format("%d", (long) def), 8);
+                    controls.put(name, seedField);
+                    controlPanel.add(seedField);
+                    JButton randomSeedButton = new JButton("Random");
+                    randomSeedButton.addActionListener(e -> {
+                        String newSeed = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+                        seedField.setText(newSeed);
+                    });
+                    controlPanel.add(randomSeedButton);
+                    if (this instanceof com.beder.texture.noise.NoiseOperation) {
+                        ((com.beder.texture.noise.NoiseOperation) this).setSeedField(seedField);
+                    }
+                    break;
 		default:
 			break;
 		}

--- a/Textures/src/com/beder/texture/noise/NoiseOperation.java
+++ b/Textures/src/com/beder/texture/noise/NoiseOperation.java
@@ -17,20 +17,19 @@ import com.beder.texture.Redrawable;
 
 public abstract class NoiseOperation extends Operation {
 
-	private JTextField seedField;
-	private JButton randomSeedButton;
+        private JTextField seedField;
 	private BufferedImage result;
 	private ImagePair input;
 	private Parameters lastPar;
 	private final static String PARAM_SEED = "Seed";
 
-	public NoiseOperation(Redrawable r) {
-		super(r);
-		result = null;
-		lastPar = new Parameters();
-		long seed = new Random().nextInt(Integer.MAX_VALUE);
-		addParameter(PARAM_SEED, CONTROL_TYPE.SEED, seed);
-	}
+        public NoiseOperation(Redrawable r) {
+                super(r);
+                result = null;
+                lastPar = new Parameters();
+                long seed = new Random().nextInt(Integer.MAX_VALUE);
+                addParameter(PARAM_SEED, CONTROL_TYPE.SEED, seed);
+        }
 
     /**
      * Called by child class to add random seed controls on the edit panel
@@ -73,10 +72,15 @@ public abstract class NoiseOperation extends Operation {
 	    return input;
 	}
 
-	public long getSeed() {
+        public long getSeed() {
         long seed = Long.parseLong(seedField.getText());
-		return seed;
-	}
+                return seed;
+        }
+
+        /** Setter used by Operation when creating the seed field component. */
+        public void setSeedField(JTextField field) {
+            this.seedField = field;
+        }
 
 	public ImagePair getInput() {
 		return input;


### PR DESCRIPTION
## Summary
- correctly store the SEED control's text field for noise operations
- expose setter for seed field in NoiseOperation
- remove unused fields

## Testing
- `javac @sources.txt` *(fails: package org.locationtech.jts.geom does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6844c324ba008327b292b6e64e377350